### PR TITLE
Make sure apt-transport-https is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
-- name: install python-pycurl
+- name: install required packages
   sudo: true
-  apt: pkg=python-pycurl
+  apt: pkg={{ item }}
+  with_items:
+  - python-pycurl
+  - apt-transport-https
 
 - name: add nodesource apt key
   sudo: true


### PR DESCRIPTION
We need <code>apt-transport-https</code> for Nodesource repository otherwise things will break (at least on Debian Wheezy):

```shell

failed: [dev.host.com] => {"failed": true, "parsed": false}
SUDO-SUCCESS-yllseojbkbfcdwqfbwdhnnpwlpyboovo
Traceback (most recent call last):
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1427053790.71-5432967364281/apt", line 2167, in <module>
    main()
  File "/home/vagrant/.ansible/tmp/ansible-tmp-1427053790.71-5432967364281/apt", line 547, in main
    cache.update()
  File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 418, in update
    raise FetchFailedException(e)
apt.cache.FetchFailedException: E:The method driver /usr/lib/apt/methods/https could not be found.


```